### PR TITLE
Add profiles

### DIFF
--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -30,7 +30,7 @@ jobs:
         pip3 install flake8 mypy --default-timeout=100
         mypy --config-file ./ci/mypy.cfg ./
         flake8 --config ./ci/flake8.cfg
-        # If this fails run: python3 -m black . --config ./ci/black.toml
+        echo If this fails run: python3 -m black . --config ./ci/black.toml
         python3 -m black . --config ./ci/black.toml --check
         python3 -m pip_audit -r requirements.txt
 

--- a/cloudgrep.py
+++ b/cloudgrep.py
@@ -1,0 +1,3 @@
+from cloudgrep import __main__
+
+__main__.main()

--- a/cloudgrep/__main__.py
+++ b/cloudgrep/__main__.py
@@ -64,7 +64,7 @@ def main() -> None:
     )
     args = vars(parser.parse_args())
 
-    if len(sys.argv)==1:
+    if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)
 

--- a/cloudgrep/__main__.py
+++ b/cloudgrep/__main__.py
@@ -1,6 +1,7 @@
 from .cloudgrep import CloudGrep
 import argparse
 import logging
+import sys
 
 VERSION = "1.0.1"
 
@@ -51,11 +52,21 @@ def main() -> None:
         default=100000000,
         required=False,
     )
+    parser.add_argument(
+        "-pr",
+        "--profile",
+        help="Set an AWS profile to use. E.g. default, dev, prod.",
+        required=False,
+    )
     parser.add_argument("-d", "--debug", help="Enable Debug logging. ", action="store_true", required=False)
     parser.add_argument(
         "-hf", "--hide_filenames", help="Dont show matching filesnames. ", action="store_true", required=False
     )
     args = vars(parser.parse_args())
+
+    if len(sys.argv)==1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
 
     if args["debug"]:
         logging.basicConfig(format="[%(asctime)s]:[%(levelname)s] - %(message)s", level=logging.INFO)
@@ -75,6 +86,7 @@ def main() -> None:
         args["start_date"],
         args["end_date"],
         args["hide_filenames"],
+        args["profile"],
     )
 
 

--- a/cloudgrep/cloudgrep.py
+++ b/cloudgrep/cloudgrep.py
@@ -286,11 +286,16 @@ class CloudGrep:
         from_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
         hide_filenames: bool = False,
+        profile: Optional[str] = None,
     ) -> None:
         # load in a list of queries from a file
         if not query and file:
             logging.info(f"Loading queries in from {file}")
             query = self.load_queries(file)
+
+        if profile:
+            # Set the AWS credentials profile to use
+            boto3.setup_default_session(profile_name=profile)
 
         # Parse dates
         parsed_from_date = None


### PR DESCRIPTION
Adds support to select which AWS profile to use:

 python3 cloudgrep.py -b bucket -q query --profile secondary

https://github.com/cado-security/cloudgrep/issues/4

