### PR TITLE
fix(waf) : handle waf log format

### DIFF
--- a/cloudgrep/__main__.py
+++ b/cloudgrep/__main__.py
@@ -63,7 +63,7 @@ def main() -> None:
 
     # Configure logging
     if args.debug:
-        logging.basicConfig(format="[%(asctime)s] [%(levelname)s] %(message)s", level=logging.INFO)
+        logging.basicConfig(format="[%(asctime)s] [%(levelname)s] %(message)s", level=logging.DEBUG)
     else:
         logging.basicConfig(format="[%(asctime)s] %(message)s", level=logging.WARNING)
         logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)

--- a/cloudgrep/__main__.py
+++ b/cloudgrep/__main__.py
@@ -46,8 +46,13 @@ def main() -> None:
         "-lp", "--log_properties", type=list_of_strings, help="Comma-separated list of log properties to extract"
     )
     parser.add_argument("-jo", "--json_output", action="store_true", help="Output results in JSON format")
+    parser.add_argument(
+        "-cd", "--convert_date", action="store_true", help="Convert date to ISO format (YYYY-MM-DDTHH:MM:SS)"
+    )
+    parser.add_argument(
+        "-og", "--use_og_name", action="store_true", help="Decide if you want to use original key name or tmporary name for uncompress files"
+    )
     args = parser.parse_args()
-
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)
@@ -58,7 +63,7 @@ def main() -> None:
 
     # Configure logging
     if args.debug:
-        logging.basicConfig(format="[%(asctime)s] [%(levelname)s] %(message)s", level=logging.DEBUG)
+        logging.basicConfig(format="[%(asctime)s] [%(levelname)s] %(message)s", level=logging.INFO)
     else:
         logging.basicConfig(format="[%(asctime)s] %(message)s", level=logging.WARNING)
         logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
@@ -82,6 +87,8 @@ def main() -> None:
         log_properties=args.log_properties,
         profile=args.profile,
         json_output=args.json_output,
+        convert_date=args.convert_date,
+        use_og_name=args.use_og_name,
     )
 
 

--- a/cloudgrep/cloud.py
+++ b/cloudgrep/cloud.py
@@ -11,7 +11,7 @@ import tempfile
 from typing import Iterator, Optional, List, Any, Tuple
 import logging
 from cloudgrep.search import Search
-
+from pytz import timezone
 class Cloud:
     def __init__(self) -> None:
         self.search = Search()
@@ -42,6 +42,8 @@ class Cloud:
         log_format: Optional[str] = None,
         log_properties: List[str] = [],
         json_output: Optional[bool] = False,
+        convert_date: bool = False,
+        use_og_name : bool = False
     ) -> int:
         """Download and search files from AWS S3"""
         if log_properties is None:
@@ -53,8 +55,9 @@ class Cloud:
             try:
                 logging.info(f"Downloading s3://{bucket}/{key} to {tmp_name}")
                 s3.download_file(bucket, key, tmp_name)
+                og_name = key if use_og_name else tmp_name
                 matched = self.search.search_file(
-                    tmp_name, key, query, hide_filenames, yara_rules, log_format, log_properties, json_output
+                    tmp_name, key, query, hide_filenames, yara_rules, log_format, log_properties, json_output, convert_date=convert_date, og_name=og_name
                 )
                 return 1 if matched else 0
             except Exception:
@@ -166,7 +169,8 @@ class Cloud:
         from_date: Optional[datetime],
         end_date: Optional[datetime],
         file_size: int,
-        max_matches: int = 1000000 # generous default
+        max_matches: int = 1000000, # generous default
+        convert_date: bool = False,
     ) -> Iterator[str]:
         """Yield a maximum of max_matches objects that match filter"""
         # Reuse the S3 client if already created; otherwise, create one
@@ -180,7 +184,7 @@ class Cloud:
             PaginationConfig={'PageSize': 1000}
         ):
             for obj in page.get("Contents", []):
-                if self.filter_object(obj, key_contains, from_date, end_date, file_size):
+                if self.filter_object(obj, key_contains, from_date, end_date, file_size, convert_date=convert_date):
                     yield obj.get("Key")
                     count += 1
                     if count >= max_matches:
@@ -227,9 +231,17 @@ class Cloud:
         from_date: Optional[datetime],
         to_date: Optional[datetime],
         file_size: int,
+        convert_date: bool = False,
     ) -> bool:
         """Filter an S3 object based on modification date, size, and key substring"""
         last_modified = obj.get("LastModified")
+        # Fix error : "TypeError: can't compare offset-naive and offset-aware datetimes"
+        if convert_date:
+            from_date = from_date.astimezone(timezone("UTC")) if from_date else None
+            to_date = to_date.astimezone(timezone("UTC")) if to_date else None
+            # Convert last_modified to UTC if it's not already
+            if isinstance(last_modified, datetime):
+                last_modified = last_modified.astimezone(timezone("UTC"))
         if last_modified:
             if from_date and last_modified < from_date:
                 return False

--- a/cloudgrep/cloudgrep.py
+++ b/cloudgrep/cloudgrep.py
@@ -26,6 +26,7 @@ class CloudGrep:
         from_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
         file_size: int = 100_000_000, # 100MB
+        convert_date: Optional[bool] = False,
     ) -> Dict[str, List[Any]]:
         """
         Returns a dictionary of matching files for each cloud provider.
@@ -37,7 +38,7 @@ class CloudGrep:
         """
         files = {}
         if bucket:
-            files["s3"] = list(self.cloud.get_objects(bucket, prefix, key_contains, from_date, end_date, file_size))
+            files["s3"] = list(self.cloud.get_objects(bucket, prefix, key_contains, from_date, end_date, file_size, convert_date=convert_date))
         if account_name and container_name:
             files["azure"] = list(
                 self.cloud.get_azure_objects(
@@ -69,6 +70,8 @@ class CloudGrep:
         profile: Optional[str] = None,
         json_output: bool = False,
         files: Optional[Dict[str, List[Any]]] = None,
+        convert_date: Optional[bool] = False,
+        use_og_name: Optional[bool] = False,
     ) -> None:
         """
         Searches the contents of files matching the given queries.
@@ -76,6 +79,7 @@ class CloudGrep:
         If the optional `files` parameter is provided (a dict with keys such as "s3", "azure", or "gcs")
         then the search will use those file lists instead of applying the filters again.
         """
+        logging.info(f"Convert Date: {convert_date}")
         if not query and file:
             logging.debug(f"Loading queries from {file}")
             query = self.load_queries(file)
@@ -98,6 +102,9 @@ class CloudGrep:
             elif log_type.lower() == "azure":
                 log_format = "json"
                 log_properties = ["data"]
+            elif log_type.lower() == "waf":
+                log_format = "jsonl"
+                log_properties = None
             else:
                 logging.error(f"Invalid log_type: {log_type}")
                 return
@@ -109,14 +116,14 @@ class CloudGrep:
                 matching_keys = files["s3"]
             else:
                 matching_keys = list(
-                    self.cloud.get_objects(bucket, prefix, key_contains, from_date, end_date, file_size)
+                    self.cloud.get_objects(bucket, prefix, key_contains, from_date, end_date, file_size, convert_date=convert_date)
                 )
             s3_client = boto3.client("s3")
             region = s3_client.get_bucket_location(Bucket=bucket).get("LocationConstraint", "unknown")
             logging.warning(f"Bucket region: {region}. (Search from the same region to avoid egress charges.)")
             logging.warning(f"Searching {len(matching_keys)} files in {bucket} for {query}...")
             self.cloud.download_from_s3_multithread(
-                bucket, matching_keys, query, hide_filenames, yara_rules, log_format, log_properties, json_output
+                bucket, matching_keys, query, hide_filenames, yara_rules, log_format, log_properties, json_output, convert_date=convert_date, use_og_name=use_og_name
             )
 
         if account_name and container_name:

--- a/cloudgrep/cloudgrep.py
+++ b/cloudgrep/cloudgrep.py
@@ -79,7 +79,6 @@ class CloudGrep:
         If the optional `files` parameter is provided (a dict with keys such as "s3", "azure", or "gcs")
         then the search will use those file lists instead of applying the filters again.
         """
-        logging.info(f"Convert Date: {convert_date}")
         if not query and file:
             logging.debug(f"Loading queries from {file}")
             query = self.load_queries(file)

--- a/cloudgrep/search.py
+++ b/cloudgrep/search.py
@@ -30,7 +30,16 @@ class Search:
             print(f"{output.get('key_name', '')}: {line}" if not hide_filenames else line)
 
     def parse_logs(self, line: str, log_format: Optional[str]) -> Any:
-        if log_format == "json":
+        if log_format == "jsonl":
+            try:
+                # JSON Lines format (each line is a separate JSON object)
+                # This is a common format for logs, especially in cloud environments
+                # where each log entry is a separate line.
+                line_split = line.strip().split("\n")
+                return line_split
+            except json.JSONDecodeError as e:
+                logging.error(f"JSON decode error in line: {line} ({e})")
+        elif log_format == "json":
             try:
                 return json.loads(line)
             except json.JSONDecodeError as e:
@@ -84,13 +93,14 @@ class Search:
         log_format: Optional[str],
         log_properties: List[str] = [],
         json_output: Optional[bool] = False,
+        convert_date: Optional[bool] = False,
     ) -> bool:
         """Regex search of the line"""
         found = False
         for regex in compiled_patterns:
             if regex.search(line):
                 if log_format:
-                    self.search_logs(line, key_name, regex.pattern, hide_filenames, log_format, log_properties, json_output)
+                    self.search_logs(line, key_name, regex.pattern, hide_filenames, log_format, log_properties, json_output, convert_date)
                 else:
                     self.print_match(
                         {"key_name": key_name, "query": regex.pattern, "line": line}, hide_filenames, json_output
@@ -122,6 +132,8 @@ class Search:
         log_properties: List[str] = [],
         json_output: Optional[bool] = False,
         account_name: Optional[str] = None,
+        convert_date: Optional[bool] = False,
+        og_name: Optional[str] = None,
     ) -> bool:
         """Regex search of the file line by line"""
         logging.info(f"Searching {file_name} for patterns: {patterns}")
@@ -132,11 +144,10 @@ class Search:
 
         def process_lines(lines: Iterable[str]) -> bool:
             return any(
-                self.search_line(key_name, compiled_patterns, hide_filenames, line, log_format, log_properties, json_output)
+                self.search_line(key_name, compiled_patterns, hide_filenames, line, log_format, log_properties, json_output, convert_date)
                 for line in lines
             )
-
-        if file_name.endswith(".gz"):
+        if file_name.endswith(".gz") or og_name.endswith(".gz"):
             try:
                 with gzip.open(file_name, "rt", encoding="utf-8", errors="ignore") as f:
                     if account_name:
@@ -147,7 +158,7 @@ class Search:
             except Exception:
                 logging.exception(f"Error processing gzip file: {file_name}")
                 return False
-        elif file_name.endswith(".zip"):
+        elif file_name.endswith(".zip") or og_name.endswith(".zip"):
             matched_any = False
             try:
                 with zipfile.ZipFile(file_name, "r") as zf:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ azure-identity==1.16.1
 google-cloud-storage==2.12.0
 setuptools==70.0.0
 yara-python-wheel==4.4.0
+pytz==2025.2


### PR DESCRIPTION
#42 

I add two options to fix 2 bugs I found when running the script.

N°1 : `--convert_date`

> Traceback (most recent call last):
>   File "/Users/adrien/cloudgrep/cloudgrep.py", line 3, in <module>
>     __main__.main()
>   File "/Users/adrien/cloudgrep/cloudgrep/__main__.py", line 69, in main
>     CloudGrep().search(
>   File "/Users/adrien/cloudgrep/cloudgrep/cloudgrep.py", line 117, in search
>     matching_keys = list(
>                     ^^^^^
>   File "/Users/adrien/cloudgrep/cloudgrep/cloud.py", line 186, in get_objects
>     if self.filter_object(obj, key_contains, from_date, end_date, file_size, convert_date=convert_date):
>        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/adrien/cloudgrep/cloudgrep/cloud.py", line 246, in filter_object
>     if from_date and last_modified < from_date:
>                      ^^^^^^^^^^^^^^^^^^^^^^^^^
> TypeError: can't compare offset-naive and offset-aware datetimes

I force conversion of from_date, end_date and last_modified variables using [pytz](https://pypi.org/project/pytz/)

N°2: `--use_og_name`

When deciding if file should be uncompressed, script looks for .gz extension in tmp_name file generated by tempfile and not in original bucket key